### PR TITLE
v1.0.16 feature update

### DIFF
--- a/GatherMate2Marker.toc
+++ b/GatherMate2Marker.toc
@@ -3,7 +3,7 @@
 ## X-FullName: GatherMate 2 Marker
 ## Author: Froboz @ Old Blanchy (TBC Classic)
 ## Notes: Mark mini-map nodes as seen. Requires GatherMate2.
-## Version: 1.0.15
+## Version: 1.0.16
 ## Dependencies: GatherMate2
 ## SavedVariables: GatherMate2MarkerDB
 ## X-Curse-Project-ID: 565501


### PR DESCRIPTION
Automatically enable Find Herbs if it's not ticked. Gather Mate (and this addon) both reacted to found Herb nodes, but no actual found herbs were showing up on the mini-map: this update ensures that Find Herbs is enabled. (Can disable this via a checkbox in the GatherMate2Marker options).